### PR TITLE
Update README with docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Run3 Game Engine 
+# Run3 Game Engine
 
-Run3 development started in 2009, after experiments with Ogre. Highly inspired by Source, it has open-structure and overall flexibility as basis. 
-To put it simple, Run3 exists as a run3_r.exe executable file and related DLL's. There is no specific content creation tool for it. You can use any of them.  
-Specific Run3 tools involve RunEdit(legacy map editor), RunRepresent(model viewer), FacialAnimation(lip sync app), Run3Mat(console until for material batching). Also I use Ogitor for mapping, CaduneTree for procedural trees, CEGUI Editor for the menu GUI, CEGUIMeshViewer for mesh fixing.  
+Run3 is an open-source game engine built with Ogre and inspired by the Source engine. The project started in 2009 and is licensed under the [MIT License](LICENSE).
 
-# Please follow Run3 Wiki for more information
+Run3 exists as a `run3_r.exe` executable and related DLLs. There are no dedicated content creation tools; you can work with whichever tools you prefer. Existing utilities include RunEdit (a legacy map editor), RunRepresent (model viewer), FacialAnimation (lip sync), and Run3Mat (a console utility for material batching). Ogitor assists with mapping, CaduneTree for procedural trees, the CEGUI Editor for GUI, and CEGUIMeshViewer for mesh fixing.
+
+## Documentation
+
+For a high‑level overview see [docs/index.md](docs/index.md). Build instructions are located in [docs/BUILDING.md](docs/BUILDING.md).

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,0 +1,9 @@
+# Building Run3
+
+This document describes how to build the Run3 Game Engine from source.
+
+1. Ensure you have a C++ compiler and the required dependencies installed.
+2. Generate the project files or makefiles using your preferred build system.
+3. Compile the source code and link the engine binaries.
+
+More detailed instructions will be provided in the future.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Run3 Documentation
+
+Welcome to the Run3 documentation. This section provides an overview of the engine and available features.
+
+Additional guides and technical details will be added here.


### PR DESCRIPTION
## Summary
- describe Run3 as an open-source engine under MIT
- add `docs/` directory with overview and building notes
- link from README to `docs/index.md` and `docs/BUILDING.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685424c0ae9c8323bc65750287b1897d