### PR TITLE
Add documentation for building and tools

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,9 +1,26 @@
-# Building Run3
+# Building Run3 on Windows
 
-This document describes how to build the Run3 Game Engine from source.
+This guide outlines the basic steps to compile the engine using **Visual Studio**.
 
-1. Ensure you have a C++ compiler and the required dependencies installed.
-2. Generate the project files or makefiles using your preferred build system.
-3. Compile the source code and link the engine binaries.
+## Prerequisites
 
-More detailed instructions will be provided in the future.
+Before opening the project you should install the following SDKs or libraries and set up their environment variables where appropriate:
+
+- **Ogre3D SDK** (`OGRE_HOME`)
+- **OIS** (`OIS_HOME`)
+- **CEGUI** (`CEGUI_HOME`)
+- **OpenAL** (`OPENAL_SDK`)
+- **OgreNewt** (`OGRENEWT_HOME`)
+
+Other dependencies (Lua, Newton, etc.) may be required depending on the configuration of `Run3.vcproj`.
+
+## Loading the Solution
+
+1. Open `Run3.sln` in Visual Studio. Older versions of Visual Studio may instead load `Run3.vcproj` directly.
+2. Ensure the include and library directories for the above dependencies are reachable. This is typically handled via the environment variables shown above.
+
+## Building
+
+Select either the *Debug* or *Release* configuration and choose **Build Solution**. Visual Studio will compile the `run3` executable and accompanying DLLs inside the configured output directory.
+
+After a successful build you can run the engine from the build folder.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,19 @@
+# Run3 Tools
+
+The engine is accompanied by a set of utilities that assist with content creation and asset management.
+
+## RunEdit
+
+A legacy map editor used to build game levels. It predates more modern editors but can still load and save basic geometry for the engine.
+
+## RunRepresent
+
+A simple model viewer for inspecting meshes and materials before exporting them to the game.
+
+## FacialAnimation
+
+Utility for creating lip‑sync and facial animation data from audio samples.
+
+## Run3Mat
+
+Console tool that batches material scripts for faster loading in the engine.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,23 @@
-# Run3 Documentation
+# Run3 Engine Overview
 
-Welcome to the Run3 documentation. This section provides an overview of the engine and available features.
+Run3 is an experimental open-source game engine built around the **Ogre3D** rendering library. It aims to provide Source-engine style gameplay features while remaining fully moddable. The code base is written in C++ and integrates several middleware libraries for graphics, physics and sound.
 
-Additional guides and technical details will be added here.
+## Key Dependencies
+
+- **Ogre3D** – primary rendering engine
+- **OIS** – input handling
+- **CEGUI** – graphical user interface system
+- **OpenAL** – audio playback
+- **OgreNewt** – physics and collision
+
+## Architecture
+
+At a high level the engine is organized into a few major modules:
+
+- **Rendering** – custom scene managers and deferred shading built on top of Ogre3D.
+- **Physics** – simulation using OgreNewt, with helpers for ragdolls and rigid bodies.
+- **Sound** – OpenAL based sound manager for in‑game audio.
+- **Input & UI** – OIS for keyboard/mouse and CEGUI for menus and HUDs.
+- **Game Systems** – gameplay logic, AI, scripting and other utilities.
+
+This documentation section will grow with additional guides and references.


### PR DESCRIPTION
## Summary
- expand project overview in `docs/index.md`
- document Windows build process in `docs/BUILDING.md`
- add a new `docs/TOOLS.md` page about Run3 utilities

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68587620db148323ab7a60cca4d162f7